### PR TITLE
Generalize runOptimization.py to USER when installed in user home (adds Py>3.6 dependency)

### DIFF
--- a/Tests/Optimization/Himmelblau/Unconstrained/runOptimization.py
+++ b/Tests/Optimization/Himmelblau/Unconstrained/runOptimization.py
@@ -2,7 +2,7 @@ import os
 import numpy as np
 import pandas as pd 
 
-RODEO_HOME = "/home/eoezkaya/RoDeO"
+RODEO_HOME = f"/home/{os.environ['USER']}/RoDeO"
 BIN_RODEO = RODEO_HOME + "/build/rodeo"
 configFilename = "himmelblau.cfg"
 # compile the code that evaluates the objective function

--- a/Tests/Optimization/Himmelblau/UnconstrainedUsingGradients/runOptimization.py
+++ b/Tests/Optimization/Himmelblau/UnconstrainedUsingGradients/runOptimization.py
@@ -2,7 +2,7 @@ import os
 import numpy as np
 import pandas as pd 
 
-RODEO_HOME = "/home/eoezkaya/RoDeO"
+RODEO_HOME = f"/home/{os.environ['USER']}/RoDeO"
 BIN_RODEO = RODEO_HOME + "/build/rodeo"
 configFilename = "himmelblau.cfg"
 # compile the code that evaluates the objective function


### PR DESCRIPTION
Making a generalization to the `RODEO_HOME` variable using f-strings (Python version $\geq$ 3.6 ). 
Otherwise could simply read and concatenate from reading the value directly, to make it work in Py 2.